### PR TITLE
Function to access entity attributes, such as state

### DIFF
--- a/homeassistant_api/rawclient.py
+++ b/homeassistant_api/rawclient.py
@@ -99,11 +99,18 @@ class RawClient(RawWrapper):
         res = self.request('states')
         return [self._process_entity_json(json) for json in res]
 
-    def get_entity(self, entity_id):
+    def get_entity(self, entity_id, attribute="entity_id"):
         if self.malformed_id(entity_id):
             raise MalformedDataError('"{}" is not a valid entity_id, check your spelling and try again.'.format(entity_id))
         res = self.request(f'states/{entity_id}')
         return self._process_entity_json(res)
+
+    def get_entity_info(self, entity_id, attribute="entity_id"):
+        # access entity attributes: attributes, context, entity_id, last_changed, last_updated, state
+        if self.malformed_id(entity_id):
+            raise MalformedDataError('"{}" is not a valid entity_id, check your spelling and try again.'.format(entity_id))
+        res = self.request(f'states/{entity_id}')
+        return res[attribute]
 
     def get_discovery_info(self):
         res = self.request('discovery_info')

--- a/homeassistant_api/rawclient.py
+++ b/homeassistant_api/rawclient.py
@@ -99,7 +99,7 @@ class RawClient(RawWrapper):
         res = self.request('states')
         return [self._process_entity_json(json) for json in res]
 
-    def get_entity(self, entity_id, attribute="entity_id"):
+    def get_entity(self, entity_id):
         if self.malformed_id(entity_id):
             raise MalformedDataError('"{}" is not a valid entity_id, check your spelling and try again.'.format(entity_id))
         res = self.request(f'states/{entity_id}')


### PR DESCRIPTION
Was looking for a way to check the state of an entity (e.g. if a switch is 'on' or 'off'), I think adding a function like this would solve it. 
Another solution could be a function that returns the unprocessed request to /states/{entity_id}. 