### PR TITLE
Fixed hasattr recursion error for `Domain`

### DIFF
--- a/homeassistant_api/models/domains.py
+++ b/homeassistant_api/models/domains.py
@@ -32,7 +32,7 @@ class Domain:
 
     def __getattr__(self, attr: str):
         """Allows services accessible as attributes"""
-        if hasattr(self, attr):
+        if attr in self.__dict__:
             return super().__getattribute__(attr)
         if attr in self.services:
             return self.get_service(attr)


### PR DESCRIPTION
Yay! Temporarily switched to `__dict__`.
In the coming weeks, I plan on adding a try-except system. Perhaps that might be more intuitive for developers who don't know what `__dict__` does. We'll see.

Fixes issue #26