### PR TITLE
Fixed [Library Bug] Missing `py.typed` marker #83

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ homepage = "https://github.com/GrandMoff100/HomeAssistantAPI"
 license = "GPL-3.0-or-later"
 name = "HomeAssistant-API"
 readme = "README.md"
+include = ["homeassistant_api/py.typed"]
 repository = "https://github.com/GrandMoff100/HomeAssistantAPI"
 version = "3.0.1.post1"
 [tool.poetry.dependencies]


### PR DESCRIPTION
Closes #83 