### PR TITLE
Fixed API reference methods not showing reference links

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,4 @@
 tasks:
-  - before: |
-      echo $GPG_KEY | base64 -d | gpg --import --pinentry=loopback --passphrase "$GPG_PASSPHRASE"
-      echo 'pinentry-mode loopback' >> ~/.gnupg/gpg.conf
-      git config --local user.signingkey $GPG_KEY_ID
-      git config --local commit.gppsign true
   - init: |
       pip install poetry
       poetry config virtualenvs.create false

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,118 +1,76 @@
-@import "../basic.css";
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+Mono&family=Roboto+Condensed:wght@700&family=Source+Sans+Pro&display=swap");
+@import '../basic.css';
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Mono&family=Rubik&family=Varela+Round&display=swap');
 
 img {
-  margin-bottom: 10px;
-  width: 80%;
-  height: auto;
-  border-radius: 10px;
+    margin-bottom: 10px;
+    width: 80%;
+    height: auto;
+    border-radius: 10px;
 }
 
-/*
 div.sphinxsidebarwrapper {
     margin-right: 30px;
 }
-*/
 
 div.sphinxsidebar {
-  width: 260px;
-  font-size: 14px;
-  line-height: 1.5;
+    width: 260px;
+    font-size: 14px;
+    line-height: 1.5;
 }
 
 .wy-nav-content {
-  max-width: 1500px;
-  width: 70%;
+    max-width: none;
 }
 
 .rst-content img {
-  max-width: 800px;
-  width: 80%;
-  margin-bottom: 3%;
+    max-width: 800px;
+    width: 80%;
+    margin-bottom: 3%;
 }
 
-.rst-content div[class^="highlight"],
-.rst-content pre.literal-block {
-  border: transparent;
-  overflow-x: auto;
-  margin: 1px 0 24px;
-  border-radius: 10px;
-  background: #f1f1f1;
+.rst-content div[class^="highlight"], .rst-content pre.literal-block {
+    border: transparent;
+    overflow-x: auto;
+    margin: 1px 0 24px;
+    border-radius: 10px;
+    background: #f1f1f1;
 }
 
-.rst-content .linenodiv pre,
-.rst-content div[class^="highlight"] pre,
-.rst-content pre.literal-block {
-  font-family: "Noto Sans Mono", monospace;
-  font-size: 12px;
-  line-height: 1.4;
+.rst-content .linenodiv pre, .rst-content div[class^="highlight"] pre, .rst-content pre.literal-block {
+    font-family: 'Noto Sans Mono', monospace;
+    font-size: 12px;
+    line-height: 1.4;
 }
 
-.rst-content .toctree-wrapper > p.caption,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-legend {
-  margin-top: 0;
-  font-weight: 700;
-
-  /* font-family: 'Roboto Condensed', sans-serif; */
+.rst-content .toctree-wrapper > p.caption, h1, h2, h3, h4, h5, h6, legend {
+    margin-top: 0;
+    font-weight: 700;
+    font-family: 'Varela Round', sans-serif;
 }
 
 body {
-  font-family: "Source Sans Pro", sans-serif;
-  font-weight: 400;
-  color: #404040;
+    font-family: 'Rubik', sans-serif;
+    font-weight: 400;
+    color: #404040;
 }
 
-.rst-content code.literal,
-.rst-content tt.literal {
-  color: #373737;
-  white-space: normal;
-  border-radius: 0.5em;
-  padding: 0.4% 0.4% 0.3%;
-  background: #e8e8e8;
-  border: transparent;
+.rst-content code.literal, .rst-content tt.literal {
+    color: #373737;
+    white-space: normal;
+    border-radius: 0.5em;
+    padding: 0.4% 0.4% 0.3%;
+    background: #e8e8e8;
+    border: transparent;
 }
 
 .ethical-rst {
-  visibility: hidden;
+    visibility: hidden;
 }
 
 .wy-side-nav-search {
-  background: #4a94c4;
+    background: #4a94c4;
 }
 
 .version {
-  color: #d9d9d9;
-}
-
-dt {
-  padding-left: 6px;
-  padding-right: 6px;
-}
-
-.sig {
-  border-radius: 0.3142em;
-}
-
-/* csslint ignore:start */
-html.writer-html4 .rst-content dl:not(.docutils) > dt,
-html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) > dt {
-  border: 1px solid #72cdf7;
-}
-
-html.writer-html4 .rst-content dl:not(.docutils) dl:not(.field-list) > dt,
-html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list) > dt {
-  border: 1px solid #adadad;
-}
-
-/* csslint ignore:end */
-
-.py > .headerlink {
-  visibility: hidden !important;
-  position: absolute !important;
+    color: #d9d9d9;
 }

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,5 +1,3 @@
-.. _quickstart:
-
 ***********
 Quickstart
 ***********

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -97,8 +97,8 @@ Using Client with :code:`async`/:code:`await`
 Are you wondering if you can use :code:`homeassistant_api` using Python's :code:`async`/:code:`await` syntax?
 Good news! You can!
 
-Services
-************
+Async Services
+********************
 .. code-block:: python
 
     import asyncio
@@ -120,8 +120,8 @@ Services
 
     asyncio.get_event_loop().run_until_complete(main())
 
-Entities
-*********
+Async Entities
+*****************
 
 .. code-block:: python
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -2,7 +2,7 @@ import os
 
 from homeassistant_api import Client
 
-api_url = "https://larsen-hassio.duckdns.org:8123/api"  # Something like http://localhost:8123/api
+api_url = "https://homeassistant.duckdns.org:8123/api"  # Something like http://localhost:8123/api
 token = os.getenv(
     "HOMEASSISTANT_TOKEN"
 )  # Used to aunthenticate yourself with homeassistant


### PR DESCRIPTION
Autogenerated docs now show clickable link elements, to cross-reference methods, classes, etc when mouse hovers over them like this.
![image](https://user-images.githubusercontent.com/51765903/158728166-2b8fc9b7-02d8-4712-9142-664306510bae.png)
