### PR TITLE
Replace d.get(k, None) calls with d.get(k)

### DIFF
--- a/homeassistant_api/_async/models/domains.py
+++ b/homeassistant_api/_async/models/domains.py
@@ -32,7 +32,7 @@ class AsyncDomain(BaseModel):
 
     def get_service(self, service_id: str):
         """Return a Service with the given service_id, returns None if no such service exists"""
-        return self.services.get(service_id, None)
+        return self.services.get(service_id)
 
     def __getattr__(self, attr: str):
         """Allows services accessible as attributes"""

--- a/homeassistant_api/models/domains.py
+++ b/homeassistant_api/models/domains.py
@@ -31,7 +31,7 @@ class Domain(BaseModel):
 
     def get_service(self, service_id: str):
         """Return a Service with the given service_id, returns None if no such service exists"""
-        return self.services.get(service_id, None)
+        return self.services.get(service_id)
 
     def __getattr__(self, attr: str):
         """Allows services accessible as attributes"""


### PR DESCRIPTION
A minor redundancy reduction. As `self.services` in each domain model is a dict, we can assume that `None` is the default `dict.get()` `default` parameter value.