### PR TITLE
Make ServiceField's description an Optional[str]

### DIFF
--- a/homeassistant_api/models/domains.py
+++ b/homeassistant_api/models/domains.py
@@ -72,7 +72,7 @@ class Domain(BaseModel):
 class ServiceField(BaseModel):
     """Model for service parameters/fields."""
 
-    description: str
+    description: Optional[str] = None
     example: Any
     selector: Optional[Dict[str, Any]] = None
     name: Optional[str] = None


### PR DESCRIPTION
Not all service fields have a description, so reflect this in the code. Tested on my Windows desktop, fixes incompatibility with some ESPHome devices. Fixes #120 