### PR TITLE
Allow returning raw bytes from a request, without attempting to decode.

### DIFF
--- a/homeassistant_api/errors.py
+++ b/homeassistant_api/errors.py
@@ -1,5 +1,7 @@
 """Module for custom error classes"""
 
+from typing import Union
+
 
 class HomeassistantAPIError(BaseException):
     """Base class for custom errors"""
@@ -40,10 +42,10 @@ class ParameterMissingError(HomeassistantAPIError):
 class InternalServerError(HomeassistantAPIError):
     """Error raised when Home Assistant says that it got itself in trouble."""
 
-    def __init__(self, status_code: int, content: str) -> None:
+    def __init__(self, status_code: int, content: Union[str, bytes]) -> None:
         super().__init__(
             f"Home Assistant returned a response with an error status code {status_code!r}.\n"
-            f"{content}\n"
+            f"{content!r}\n"
             "If this happened, "
             "please report it at https://github.com/GrandMoff100/HomeAssistantAPI/issues "
             "with the request status code and the request content. Thanks!"

--- a/homeassistant_api/processing.py
+++ b/homeassistant_api/processing.py
@@ -73,17 +73,17 @@ class Processing:
 
     def process(self) -> Any:
         """Validates the http status code before starting to process the repsonse content"""
+        content: Union[str, bytes]
         if async_ := isinstance(self._response, (ClientResponse, AsyncCachedResponse)):
             status_code = self._response.status
             _buffer = self._response.content._buffer
             content = b"" if not _buffer else _buffer[0]
-            if self._decode_bytes:
-                content = content.decode()
         elif isinstance(self._response, (Response, CachedResponse)):
             status_code = self._response.status_code
             content = self._response.content
-            if self._decode_bytes:
-                content = content.decode()
+        if self._decode_bytes and isinstance(content, bytes):
+            content = content.decode()
+
         if status_code in (200, 201):
             return self.process_content(async_=async_)
         if status_code == 400:
@@ -96,7 +96,7 @@ class Processing:
             method = (
                 self._response.request.method
                 if isinstance(self._response, (Response, CachedResponse))
-                else self._response.method
+                else self._response.method  # type: ignore
             )
             raise MethodNotAllowedError(cast(str, method))
         if status_code >= 500:

--- a/homeassistant_api/processing.py
+++ b/homeassistant_api/processing.py
@@ -93,11 +93,10 @@ class Processing:
         if status_code == 404:
             raise EndpointNotFoundError(str(self._response.url))
         if status_code == 405:
-            method = (
-                self._response.request.method
-                if isinstance(self._response, (Response, CachedResponse))
-                else self._response.method  # type: ignore
-            )
+            if isinstance(self._response, (Response, AsyncCachedResponse)):
+                method = self._response.request.method
+            else:
+                method = self._response.method
             raise MethodNotAllowedError(cast(str, method))
         if status_code >= 500:
             raise InternalServerError(status_code, content)

--- a/homeassistant_api/processing.py
+++ b/homeassistant_api/processing.py
@@ -93,7 +93,7 @@ class Processing:
         if status_code == 404:
             raise EndpointNotFoundError(str(self._response.url))
         if status_code == 405:
-            if isinstance(self._response, (Response, AsyncCachedResponse)):
+            if isinstance(self._response, (Response, CachedResponse)):
                 method = self._response.request.method
             else:
                 method = self._response.method

--- a/homeassistant_api/processing.py
+++ b/homeassistant_api/processing.py
@@ -37,7 +37,7 @@ class Processing:
     _response: AllResponseType
     _processors: ClassVar[Dict[str, Tuple[ProcessorType, ...]]] = {}
 
-    def __init__(self, response: AllResponseType, decode_bytes: bool = False) -> None:
+    def __init__(self, response: AllResponseType, decode_bytes: bool = True) -> None:
         self._response = response
         self._decode_bytes = decode_bytes
 

--- a/homeassistant_api/processing.py
+++ b/homeassistant_api/processing.py
@@ -76,7 +76,7 @@ class Processing:
         if async_ := isinstance(self._response, (ClientResponse, AsyncCachedResponse)):
             status_code = self._response.status
             _buffer = self._response.content._buffer
-            content = b"" if not _buffer else _buffer[0].decode()
+            content = b"" if not _buffer else _buffer[0]
             if self._decode_bytes:
                 content = content.decode()
         elif isinstance(self._response, (Response, CachedResponse)):

--- a/homeassistant_api/rawclient.py
+++ b/homeassistant_api/rawclient.py
@@ -83,6 +83,7 @@ class RawClient(RawBaseClient):
         path,
         method="GET",
         headers: Dict[str, str] = None,
+        decode_bytes: bool = False,
         **kwargs,
     ) -> Any:
         """Base method for making requests to the api"""
@@ -101,12 +102,12 @@ class RawClient(RawBaseClient):
             raise RequestTimeoutError(
                 f'Home Assistant did not respond in time (timeout: {kwargs.get("timeout", 300)} sec)'
             ) from err
-        return self.response_logic(resp)
+        return self.response_logic(response=resp, decode_bytes=decode_bytes)
 
     @classmethod
-    def response_logic(cls, response: ResponseType) -> Any:
+    def response_logic(cls, response: ResponseType, decode_bytes: bool = False) -> Any:
         """Processes responses from the API and formats them"""
-        return Processing(response=response).process()
+        return Processing(response=response, decode_bytes=decode_bytes).process()
 
     # API information methods
     def get_error_log(self) -> str:

--- a/homeassistant_api/rawclient.py
+++ b/homeassistant_api/rawclient.py
@@ -83,7 +83,7 @@ class RawClient(RawBaseClient):
         path,
         method="GET",
         headers: Dict[str, str] = None,
-        decode_bytes: bool = False,
+        decode_bytes: bool = True,
         **kwargs,
     ) -> Any:
         """Base method for making requests to the api"""
@@ -105,7 +105,7 @@ class RawClient(RawBaseClient):
         return self.response_logic(response=resp, decode_bytes=decode_bytes)
 
     @classmethod
-    def response_logic(cls, response: ResponseType, decode_bytes: bool = False) -> Any:
+    def response_logic(cls, response: ResponseType, decode_bytes: bool = True) -> Any:
         """Processes responses from the API and formats them"""
         return Processing(response=response, decode_bytes=decode_bytes).process()
 


### PR DESCRIPTION
Some API calls can return binary data, e.g. fetching a user's profile image (e.g. api path like `/api/image/serve/<hash>/512x512`).

Currently this library attempts to decode all responses from `bytes` to `str` using the default `utf-8` encoding, which fails for API calls returning binary data since the first byte of e.g. JPEG data (`0xFF`) can't be decoded to text.

This PR adds a by-default-no-change-to-external-behaviour flag to the `RawClient.request` method to optionally disable decoding for that request, just returning the raw bytes.