### PR TITLE
Modernize StrEnum usage

### DIFF
--- a/homeassistant_api/models/config_entries.py
+++ b/homeassistant_api/models/config_entries.py
@@ -1,12 +1,12 @@
 """File for models used in responses from config entries."""
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from .base import BaseModel
 
 
-class FlowResultType(Enum):
+class FlowResultType(StrEnum):
     """Result type for a data entry flow."""
 
     FORM = "form"
@@ -79,7 +79,7 @@ class DisableEnableResult(BaseModel):
     require_restart: bool
 
 
-class IntegrationTypes(Enum):
+class IntegrationTypes(StrEnum):
     """Types of integrations."""
 
     ENTITY = "entity"
@@ -92,7 +92,7 @@ class IntegrationTypes(Enum):
     VIRTUAL = "virtual"
 
 
-class ConfigEntryState(str, Enum):
+class ConfigEntryState(StrEnum):
     """Config entry state."""
 
     LOADED = "loaded"
@@ -105,7 +105,7 @@ class ConfigEntryState(str, Enum):
     UNLOAD_IN_PROGRESS = "unload_in_progress"
 
 
-class ConfigEntryDisabler(Enum):
+class ConfigEntryDisabler(StrEnum):
     """What disabled a config entry."""
 
     USER = "user"
@@ -144,7 +144,7 @@ class ConfigSubEntry(BaseModel):
     unique_id: str | None
 
 
-class ConfigEntryChange(str, Enum):
+class ConfigEntryChange(StrEnum):
     """What was changed in a config entry."""
 
     ADDED = "added"

--- a/homeassistant_api/models/domains.py
+++ b/homeassistant_api/models/domains.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -159,25 +159,25 @@ class SelectBoxOptionImage(BaseModel):
     flip_rtl: bool | None = None
 
 
-class ServiceFieldSelectorNumberMode(str, Enum):
+class ServiceFieldSelectorNumberMode(StrEnum):
     BOX = "box"
     SLIDER = "slider"
 
 
-class ServiceFieldSelectorSelectMode(str, Enum):
+class ServiceFieldSelectorSelectMode(StrEnum):
     LIST = "list"
     DROPDOWN = "dropdown"
     BOX = "box"
 
 
-class ServiceFieldSelectorQRCodeErrorCorrectionLevel(str, Enum):
+class ServiceFieldSelectorQRCodeErrorCorrectionLevel(StrEnum):
     LOW = "low"
     MEDIUM = "medium"
     QUARTILE = "quartile"
     HIGH = "high"
 
 
-class ServiceFieldSelectorTextType(str, Enum):
+class ServiceFieldSelectorTextType(StrEnum):
     NUMBER = "number"
     TEXT = "text"
     SEARCH = "search"

--- a/homeassistant_api/models/entity_registry.py
+++ b/homeassistant_api/models/entity_registry.py
@@ -1,6 +1,6 @@
 """Models for Home Assistant entity registry responses."""
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field
@@ -9,7 +9,7 @@ from .base import BaseModel
 from .base import DatetimeIsoField
 
 
-class EntityDisabledBy(str, Enum):
+class EntityDisabledBy(StrEnum):
     """What disabled an entity."""
 
     CONFIG_ENTRY = "config_entry"
@@ -19,14 +19,14 @@ class EntityDisabledBy(str, Enum):
     USER = "user"
 
 
-class EntityHiddenBy(str, Enum):
+class EntityHiddenBy(StrEnum):
     """What hid an entity."""
 
     INTEGRATION = "integration"
     USER = "user"
 
 
-class EntityCategory(str, Enum):
+class EntityCategory(StrEnum):
     """Category of an entity."""
 
     CONFIG = "config"


### PR DESCRIPTION
Sorry for hijacking your rework branch, but it looks like making PRs for the main branch does not make much sense now.

Since the minimum version of Python is 3.11 now, we might as well use `StrEnum`s instead of the older `str, Enum` approach.