### PR TITLE
Fix aliases typing

### DIFF
--- a/homeassistant_api/models/entity_registry.py
+++ b/homeassistant_api/models/entity_registry.py
@@ -61,7 +61,7 @@ class EntityRegistryEntry(BaseModel):
 class EntityRegistryEntryExtended(EntityRegistryEntry):
     """Extended entity registry entry as returned by ``config/entity_registry/get`` and ``update``."""
 
-    aliases: list[str] = Field(default_factory=list)
+    aliases: list[str] | tuple[None] = Field(default_factory=list)
     capabilities: dict[str, Any] | None = None
     device_class: str | None = None
     original_device_class: str | None = None


### PR DESCRIPTION
Looks like the latest? (Changed 4 weeks ago in the codebase) version of Home Assistant changed the way that aliases are handled.

This PR adds a `tuple[None]` as an accepted value  (instead of just adding `None` as an accepted value)  (I'm guessing that None is only present by itself).

The WebSocket method's type is:
```python
vol.Optional("aliases"): [vol.Any(str, None)],
```

So mirroring that with:
```python
aliases: list[str | None] = Field(default_factory=list)
```
Might be better.