### PR TITLE
Improve usability of config/entity_registry/update parameters

### DIFF
--- a/homeassistant_api/asyncwebsocket.py
+++ b/homeassistant_api/asyncwebsocket.py
@@ -27,6 +27,7 @@ from homeassistant_api.models.config_entries import DisableEnableResult
 from homeassistant_api.models.config_entries import FlowResult
 from homeassistant_api.models.entity_registry import EntityRegistryEntry
 from homeassistant_api.models.entity_registry import EntityRegistryEntryExtended
+from homeassistant_api.models.entity_registry import EntityRegistryUpdateParams
 from homeassistant_api.models.entity_registry import EntityRegistryUpdateResult
 from homeassistant_api.models.states import Context
 from homeassistant_api.models.websocket import AuthInvalid
@@ -713,8 +714,7 @@ class AsyncWebsocketClient(BaseWebsocketClient):
 
     async def update_entity_registry_entry(
         self,
-        entity_id: str,
-        **kwargs: Any,
+        parameters: EntityRegistryUpdateParams,
     ) -> EntityRegistryUpdateResult:
         """
         Update an entity registry entry.
@@ -724,8 +724,7 @@ class AsyncWebsocketClient(BaseWebsocketClient):
         result = await self.recv_result_dict(
             await self.send(
                 "config/entity_registry/update",
-                entity_id=entity_id,
-                **kwargs,
+                **parameters,
             ),
         )
         return EntityRegistryUpdateResult.from_json(result)

--- a/homeassistant_api/models/entity_registry.py
+++ b/homeassistant_api/models/entity_registry.py
@@ -2,8 +2,10 @@
 
 from enum import Enum
 from typing import Any
+from typing import TypedDict
 
 from pydantic import Field
+from typing_extensions import NotRequired
 
 from .base import BaseModel
 from .base import DatetimeIsoField
@@ -59,7 +61,7 @@ class EntityRegistryEntry(BaseModel):
 
 
 class EntityRegistryEntryExtended(EntityRegistryEntry):
-    """Extended entity registry entry as returned by ``config/entity_registry/get`` and ``update``."""
+    """Extended entity registry entry as returned by ``config/entity_registry/get``."""
 
     aliases: list[str] = Field(default_factory=list)
     capabilities: dict[str, Any] | None = None
@@ -74,3 +76,22 @@ class EntityRegistryUpdateResult(BaseModel):
     entity_entry: EntityRegistryEntryExtended
     reload_delay: int | None = None
     require_restart: bool = False
+
+
+class EntityRegistryUpdateParams(TypedDict):
+    """Parameters used in ``config/entity_registry/update``."""
+
+    aliases: NotRequired[list[str]]
+    area_id: NotRequired[str | None]
+    categories: NotRequired[dict[str, str]]
+    device_class: NotRequired[str | None]
+    disabled_by: NotRequired[EntityHiddenBy | None]
+    entity_id: str
+    hidden_by: NotRequired[EntityHiddenBy | None]
+    icon: NotRequired[str | None]
+    labels: NotRequired[list[str]]
+    name: NotRequired[str | None]
+    new_entity_id: NotRequired[str]
+    # options and options_domain are inclusive, meaning only both or none of them have to be defined
+    options_domain: NotRequired[str]
+    options: NotRequired[dict[str, Any]]

--- a/homeassistant_api/websocket.py
+++ b/homeassistant_api/websocket.py
@@ -27,6 +27,7 @@ from homeassistant_api.models.config_entries import DisableEnableResult
 from homeassistant_api.models.config_entries import FlowResult
 from homeassistant_api.models.entity_registry import EntityRegistryEntry
 from homeassistant_api.models.entity_registry import EntityRegistryEntryExtended
+from homeassistant_api.models.entity_registry import EntityRegistryUpdateParams
 from homeassistant_api.models.entity_registry import EntityRegistryUpdateResult
 from homeassistant_api.models.states import Context
 from homeassistant_api.models.websocket import AuthInvalid
@@ -686,8 +687,7 @@ class WebsocketClient(BaseWebsocketClient):
 
     def update_entity_registry_entry(
         self,
-        entity_id: str,
-        **kwargs: Any,
+        parameters: EntityRegistryUpdateParams,
     ) -> EntityRegistryUpdateResult:
         """
         Update an entity registry entry.
@@ -697,8 +697,7 @@ class WebsocketClient(BaseWebsocketClient):
         result = self.recv_result_dict(
             self.send(
                 "config/entity_registry/update",
-                entity_id=entity_id,
-                **kwargs,
+                **parameters,
             ),
         )
         return EntityRegistryUpdateResult.from_json(result)

--- a/tests/test_entity_registry.py
+++ b/tests/test_entity_registry.py
@@ -4,6 +4,7 @@ from homeassistant_api import AsyncWebsocketClient
 from homeassistant_api import WebsocketClient
 from homeassistant_api.models.entity_registry import EntityRegistryEntry
 from homeassistant_api.models.entity_registry import EntityRegistryEntryExtended
+from homeassistant_api.models.entity_registry import EntityRegistryUpdateParams
 from homeassistant_api.models.entity_registry import EntityRegistryUpdateResult
 
 # A stable, always-present entity for read/update tests
@@ -29,14 +30,21 @@ def test_get_entity_registry_entry(websocket_client: WebsocketClient) -> None:
 
 def test_update_entity_registry_entry(websocket_client: WebsocketClient) -> None:
     result = websocket_client.update_entity_registry_entry(
-        _TEST_ENTITY_ID,
-        name="Test Name",
+        EntityRegistryUpdateParams(
+            entity_id=_TEST_ENTITY_ID,
+            name="Test Name",
+        ),
     )
     assert isinstance(result, EntityRegistryUpdateResult)
     assert result.entity_entry.entity_id == _TEST_ENTITY_ID
     assert result.entity_entry.name == "Test Name"
     # Restore original state
-    websocket_client.update_entity_registry_entry(_TEST_ENTITY_ID, name=None)
+    websocket_client.update_entity_registry_entry(
+        EntityRegistryUpdateParams(
+            entity_id=_TEST_ENTITY_ID,
+            name=None,
+        ),
+    )
 
 
 def test_remove_entity_registry_entry(websocket_client: WebsocketClient) -> None:
@@ -72,16 +80,20 @@ async def test_async_update_entity_registry_entry(
     async_websocket_client: AsyncWebsocketClient,
 ) -> None:
     result = await async_websocket_client.update_entity_registry_entry(
-        _TEST_ENTITY_ID,
-        name="Async Test Name",
+        EntityRegistryUpdateParams(
+            entity_id=_TEST_ENTITY_ID,
+            name="Async Test Name",
+        ),
     )
     assert isinstance(result, EntityRegistryUpdateResult)
     assert result.entity_entry.entity_id == _TEST_ENTITY_ID
     assert result.entity_entry.name == "Async Test Name"
     # Restore original state
     await async_websocket_client.update_entity_registry_entry(
-        _TEST_ENTITY_ID,
-        name=None,
+        EntityRegistryUpdateParams(
+            entity_id=_TEST_ENTITY_ID,
+            name=None,
+        ),
     )
 
 


### PR DESCRIPTION
Using the current models for the `config/entity_registry/update` WebSocket method is tricky.

This PR adds a simple `TypedDict` class that contains all of the available parameters and their types for the update method, replacing the existing kwargs.

